### PR TITLE
Fix Access Denied error and simplify stuff

### DIFF
--- a/Controllers/MaintenanceController.cs
+++ b/Controllers/MaintenanceController.cs
@@ -26,7 +26,7 @@ namespace Game
             {
                 try {
                     serviceFromGame.Variables["_ServiceMaintenance::Maintenance"] = switchy;
-                    serviceFromGame.Variables["_ServiceMaintenance::AdminId"] = TCAdmin.SDK.Session.GetCurrentUser().UserId;
+                    serviceFromGame.Variables["_ServiceMaintenance::AdminUser"] = TCAdmin.SDK.Session.GetCurrentUser().UserName;
                     serviceFromGame.Variables["_ServiceMaintenance::StartTime"] = DateTime.UtcNow;
                     serviceFromGame.Save();
                 }
@@ -40,7 +40,7 @@ namespace Game
                 try
                 {
                     serviceFromGame.Variables["_ServiceMaintenance::Maintenance"] = switchy;
-                    serviceFromGame.Variables["_ServiceMaintenance::AdminId"] = "";
+                    serviceFromGame.Variables["_ServiceMaintenance::AdminUser"] = "";
                     serviceFromGame.Variables["_ServiceMaintenance::StartTime"] = "";
                     serviceFromGame.Save();
                 }

--- a/Views/Game/Service/Maintenance.cshtml
+++ b/Views/Game/Service/Maintenance.cshtml
@@ -60,8 +60,7 @@
 </style>
 
 @{
-    var adminId = Model.Service.Variables["_ServiceMaintenance::AdminId"];
-    var admin = new User(adminId);
+    var adminUser = Model.Service.Variables["_ServiceMaintenance::AdminUser"];
     var startTime = TCAdmin.SDK.Misc.Dates.UniversalTimeToCurrentTimeZone( DateTime.SpecifyKind(Model.Service.Variables["_ServiceMaintenance::StartTime"], DateTimeKind.Utc));
 }
 
@@ -78,7 +77,7 @@
                                                                                     <li>Service Owner: @Model.Service.UserName</li><br/>
                                                                                     <li>Service Id: @Model.Service.ServiceId</li><br/></ul></div><br/>
                 <row class="font-weight-bold" style="margin: auto"><text style="font-family:inherit;font-size:19px;line-height:normal;font-weight:400;margin:0 0 14px">Started By: </text>
-                    <div class="k-card-body"><text>@admin.UserName</text></div>
+                    <div class="k-card-body"><text>@adminUser</text></div>
                 <text style="font-family:inherit;font-size:19px;line-height:normal;font-weight:400;margin:0 0 14px">Time Started: </text><br/>
                     <div class="k-card-body"><text>@startTime.ToString()</text></div></row>
             </row>

--- a/Views/Game/Service/Maintenance.cshtml
+++ b/Views/Game/Service/Maintenance.cshtml
@@ -74,7 +74,7 @@
             <row class="k-card-actions k-card-actions-stretched">
                 <div class="font-weight-bold" style="margin: auto"><text style="font-family:inherit;font-size:19px;line-height:normal;font-weight:400;margin:0 0 14px">Service Information:</text><ul class="k-card-body"><li>Server Name: @Model.Service.Variables["HostName"]</li><br/>
                                                                                     <li>Service: @Model.Service.Name</li><br/>
-                                                                                    <li>Service Owner: @Model.Service.UserName</li><br/>
+                                                                                    <li>Service IP/Port: @Model.Service.ConnectionInfo</li><br/>
                                                                                     <li>Service Id: @Model.Service.ServiceId</li><br/></ul></div><br/>
                 <row class="font-weight-bold" style="margin: auto"><text style="font-family:inherit;font-size:19px;line-height:normal;font-weight:400;margin:0 0 14px">Started By: </text>
                     <div class="k-card-body"><text>@adminUser</text></div>


### PR DESCRIPTION
Not sure if I have something different on my test environment but whenever I tried to access the maintenance page as a user, I was getting "Access Denied" (full log https://paste.fragnet.net/urubowasim.md ). Isn't it a bit dangerous to call the User class with the admin's ID on a normal user's page? ( at least I believe that's why I get Access Denied)

Either way, this PR should fix the above and I've also added the server's IP to show up.

Was also trying to figure out how to block users from restarting/starting their server through the "Game Services" page (if they have multiple servers) but doesn't seem to be so easy. A "before stopped" or "before start" script like so may do the trick but hey, the idea of modules is to have less scripts 😆 

```
import clr;
from System import Exception;

if ThisService.Variables["_ServiceMaintenance::Maintenance"]:
  raise Exception("Service actions are disabled since the server is in maintenance mode");
```
(not sure if we can grab a user's role id to avoid admins not being able to do any actions)